### PR TITLE
Handle unknown migrations

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -364,9 +364,11 @@ func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationD
 	if len(existingMigrations) > 0 {
 		result = append(result, ToCatchup(migrations, existingMigrations, record)...)
 	}
-
 	// Figure out which migrations to apply
-	toApply := ToApply(migrations, record.Id, dir)
+	toApply := ToApply(migrations, existingMigrations, dir)
+	if err != nil {
+		return nil, nil, err
+	}
 	toApplyCount := len(toApply)
 	if max > 0 && max < toApplyCount {
 		toApplyCount = max
@@ -379,6 +381,10 @@ func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationD
 				Queries:   v.Up,
 			})
 		} else if dir == Down {
+			if v.Down == nil {
+				// This happens if we are trying to migrate down a migration unknown to us
+				return nil, nil, fmt.Errorf("Unable to undo unknown migration %q", v.Id)
+			}
 			result = append(result, &PlannedMigration{
 				Migration: v,
 				Queries:   v.Down,
@@ -389,34 +395,74 @@ func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationD
 	return result, dbMap, nil
 }
 
-// Filter a slice of migrations into ones that should be applied.
-func ToApply(migrations []*Migration, current string, direction MigrationDirection) []*Migration {
-	var index = -1
-	if current != "" {
-		for index < len(migrations)-1 {
-			index++
-			if migrations[index].Id == current {
+// Searches the arrays for the latest elements with common ids.
+// Returns the indexes of the common id.
+func lastCommon(left []*Migration, right []*Migration) (int, int) {
+	xIndexMatch := -1
+	yIndexMatch := 0
+	for i := 0; i < len(left); i++ {
+		existingId := left[i].Id
+		for j := yIndexMatch; j < len(right); j++ {
+			if right[j].Id == existingId {
+				xIndexMatch = i
+				yIndexMatch = j
 				break
 			}
 		}
 	}
-
-	if direction == Up {
-		return migrations[index+1:]
-	} else if direction == Down {
-		if index == -1 {
-			return []*Migration{}
-		}
-
-		// Add in reverse order
-		toApply := make([]*Migration, index+1)
-		for i := 0; i < index+1; i++ {
-			toApply[index-i] = migrations[i]
-		}
-		return toApply
+	if xIndexMatch == -1 {
+		return -1, -1 // We never found a match; the arrays have nothing in common
 	}
+	return xIndexMatch, yIndexMatch
+}
 
-	panic("Not possible")
+// Filter a slice of migrations into ones that should be applied.
+func ToApply(migrations, existingMigrations []*Migration, direction MigrationDirection) []*Migration {
+	if direction == Up {
+		return toApplyUp(migrations, existingMigrations)
+	}
+	if direction == Down {
+		return toApplyDown(migrations, existingMigrations)
+	}
+	panic("Unknown direction")
+}
+
+func toApplyUp(migrations, existingMigrations []*Migration) []*Migration {
+	if len(existingMigrations) == 0 {
+		return migrations
+	}
+	_, index := lastCommon(existingMigrations, migrations)
+	return migrations[index+1:]
+}
+
+func toApplyDown(migrations, existingMigrations []*Migration) []*Migration {
+	if len(existingMigrations) == -1 {
+		return []*Migration{}
+	}
+	// When a Migration appears in both existingMigrations and migrations,
+	// we want the Migration from migrations, since only that list has
+	// the Up and Down fields set.
+	migrationsMap := map[string]*Migration{}
+	for _, m := range existingMigrations {
+		// existingMigrations will not have Up or Down set
+		migrationsMap[m.Id] = m
+	}
+	for _, m := range migrations {
+		migrationsMap[m.Id] = m
+	}
+	allMigrations := make([]*Migration, 0, len(migrationsMap))
+	for _, m := range migrationsMap {
+		allMigrations = append(allMigrations, m)
+	}
+	sort.Sort(byId(allMigrations))
+
+	_, index := lastCommon(existingMigrations, allMigrations)
+	// Add in reverse order
+	toApply := make([]*Migration, index+1)
+	for i := 0; i < index+1; i++ {
+		toApply[index-i] = allMigrations[i]
+	}
+	return toApply
 }
 
 func ToCatchup(migrations, existingMigrations []*Migration, lastRun *Migration) []*PlannedMigration {

--- a/migrate.go
+++ b/migrate.go
@@ -395,7 +395,8 @@ func PlanMigration(db *sql.DB, dialect string, m MigrationSource, dir MigrationD
 // Searches the arrays for the latest elements with common ids.
 // Returns the indexes of the common id.
 func lastCommonMigration(left []*Migration, right []*Migration) (int, int) {
-	xIndexMatch := -1
+	const none = -1
+	xIndexMatch := none
 	yIndexMatch := 0
 	for i := 0; i < len(left); i++ {
 		existingId := left[i].Id
@@ -407,8 +408,9 @@ func lastCommonMigration(left []*Migration, right []*Migration) (int, int) {
 			}
 		}
 	}
-	if xIndexMatch == -1 {
-		return -1, -1 // We never found a match; the arrays have nothing in common
+	if xIndexMatch == none {
+		// We never found a match; the arrays have nothing in common
+		return none, none
 	}
 	return xIndexMatch, yIndexMatch
 }

--- a/sql-migrate/command_status.go
+++ b/sql-migrate/command_status.go
@@ -83,8 +83,13 @@ func (c *StatusCommand) Run(args []string) int {
 	}
 
 	for _, r := range records {
-		rows[r.Id].Migrated = true
-		rows[r.Id].AppliedAt = r.AppliedAt
+		status, ok := rows[r.Id]
+		if !ok {
+			ui.Warn(fmt.Sprintf("Migration in database %q unknown to sql-migrate; it will not be possible to migrate down this migration", r.Id))
+			continue
+		}
+		status.Migrated = true
+		status.AppliedAt = r.AppliedAt
 	}
 
 	for _, m := range migrations {

--- a/toapply_test.go
+++ b/toapply_test.go
@@ -17,7 +17,7 @@ type ToApplyMigrateSuite struct {
 var _ = Suite(&ToApplyMigrateSuite{})
 
 func (s *ToApplyMigrateSuite) TestGetAll(c *C) {
-	toApply := ToApply(toapplyMigrations, "", Up)
+	toApply := ToApply(toapplyMigrations, toapplyMigrations[0:0], Up)
 	c.Assert(toApply, HasLen, 3)
 	c.Assert(toApply[0], Equals, toapplyMigrations[0])
 	c.Assert(toApply[1], Equals, toapplyMigrations[1])
@@ -25,52 +25,43 @@ func (s *ToApplyMigrateSuite) TestGetAll(c *C) {
 }
 
 func (s *ToApplyMigrateSuite) TestGetAbc(c *C) {
-	toApply := ToApply(toapplyMigrations, "abc", Up)
+	toApply := ToApply(toapplyMigrations, toapplyMigrations[0:1], Up)
 	c.Assert(toApply, HasLen, 2)
 	c.Assert(toApply[0], Equals, toapplyMigrations[1])
 	c.Assert(toApply[1], Equals, toapplyMigrations[2])
 }
 
 func (s *ToApplyMigrateSuite) TestGetCde(c *C) {
-	toApply := ToApply(toapplyMigrations, "cde", Up)
+	toApply := ToApply(toapplyMigrations, toapplyMigrations[0:2], Up)
 	c.Assert(toApply, HasLen, 1)
 	c.Assert(toApply[0], Equals, toapplyMigrations[2])
 }
 
 func (s *ToApplyMigrateSuite) TestGetDone(c *C) {
-	toApply := ToApply(toapplyMigrations, "efg", Up)
-	c.Assert(toApply, HasLen, 0)
-
-	toApply = ToApply(toapplyMigrations, "zzz", Up)
+	toApply := ToApply(toapplyMigrations, toapplyMigrations[0:3], Up)
 	c.Assert(toApply, HasLen, 0)
 }
 
 func (s *ToApplyMigrateSuite) TestDownDone(c *C) {
-	toApply := ToApply(toapplyMigrations, "", Down)
+	toApply := ToApply(toapplyMigrations, toapplyMigrations[0:0], Down)
 	c.Assert(toApply, HasLen, 0)
 }
 
 func (s *ToApplyMigrateSuite) TestDownCde(c *C) {
-	toApply := ToApply(toapplyMigrations, "cde", Down)
+	toApply := ToApply(toapplyMigrations, toapplyMigrations[0:2], Down)
 	c.Assert(toApply, HasLen, 2)
 	c.Assert(toApply[0], Equals, toapplyMigrations[1])
 	c.Assert(toApply[1], Equals, toapplyMigrations[0])
 }
 
 func (s *ToApplyMigrateSuite) TestDownAbc(c *C) {
-	toApply := ToApply(toapplyMigrations, "abc", Down)
+	toApply := ToApply(toapplyMigrations, toapplyMigrations[0:1], Down)
 	c.Assert(toApply, HasLen, 1)
 	c.Assert(toApply[0], Equals, toapplyMigrations[0])
 }
 
 func (s *ToApplyMigrateSuite) TestDownAll(c *C) {
-	toApply := ToApply(toapplyMigrations, "efg", Down)
-	c.Assert(toApply, HasLen, 3)
-	c.Assert(toApply[0], Equals, toapplyMigrations[2])
-	c.Assert(toApply[1], Equals, toapplyMigrations[1])
-	c.Assert(toApply[2], Equals, toapplyMigrations[0])
-
-	toApply = ToApply(toapplyMigrations, "zzz", Down)
+	toApply := ToApply(toapplyMigrations, toapplyMigrations, Down)
 	c.Assert(toApply, HasLen, 3)
 	c.Assert(toApply[0], Equals, toapplyMigrations[2])
 	c.Assert(toApply[1], Equals, toapplyMigrations[1])
@@ -88,13 +79,13 @@ func (s *ToApplyMigrateSuite) TestAlphaNumericMigrations(c *C) {
 
 	sort.Sort(migrations)
 
-	toApplyUp := ToApply(migrations, "2_cde", Up)
+	toApplyUp := ToApply(migrations, migrations[0:2], Up)
 	c.Assert(toApplyUp, HasLen, 3)
 	c.Assert(toApplyUp[0].Id, Equals, "10_abc")
 	c.Assert(toApplyUp[1].Id, Equals, "35_cde")
 	c.Assert(toApplyUp[2].Id, Equals, "efg")
 
-	toApplyDown := ToApply(migrations, "2_cde", Down)
+	toApplyDown := ToApply(migrations, migrations[0:2], Down)
 	c.Assert(toApplyDown, HasLen, 2)
 	c.Assert(toApplyDown[0].Id, Equals, "2_cde")
 	c.Assert(toApplyDown[1].Id, Equals, "1_abc")


### PR DESCRIPTION
Fixes bad behavior when some migrations in the db table are unknown to the current sql-migrate instance. That might happen when one branch applies some migrations and a branch lacking those migrations tries to add some of its own.

Fixed behaviors:
- If most recent migration is unknown, migrate up reports "nothing to do"
  - Migrations are now applied
- If any migrations are unknown, `sql-migrate status` panics
  - A log warning is now emitted indicating which migrations are unknown

Some weirdness remains:
- If the latest migration is unknown `sql-migrate redo` reports "nothing to do"
- I'd rather that `sql-migrate status` include the fact of unknown statuses in the table it prints, rather than as separate warnings. I want to get some UX feedback on how that might look. Currently, the printout looks like:

```
Migration in database "20160901151959_def-1.sql" unknown to sql-migrate; it will not be possible to migrate down this migration
Migration in database "20160921154454_def-2.sql" unknown to sql-migrate; it will not be possible to migrate down this migration
+-----------------------------------------------+-------------------------------+
|                   MIGRATION                   |            APPLIED            |
+-----------------------------------------------+-------------------------------+
| 00000000000000_initial.sql         | 1970-01-01 00:00:00 +0000 UTC |
| 20160406182900_abc.sql             | 2016-04-12 20:24:51 +0000 UTC |
| 20160414135200_def.sql               | 2016-10-12 20:54:49 +0000 UTC |
| 20161021194400_hig.sql                | no                            |
+-----------------------------------------------+-------------------------------+
```
